### PR TITLE
Add token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,21 @@ export default (ctx) => {
 #### Dependency registration
 
 ```js
-import I18n, {I18nToken, I18nLoaderToken} from 'fusion-plugin-i18n';
+import {I18nLoaderToken, HydrationStateToken} from 'fusion-plugin-i18n';
 import {FetchToken} from 'fusion-tokens';
 
-app.register(I18nToken, I18n);
-__NODE__
-  ? app.register(I18nLoaderToken, I18nLoader);
-  : app.register(FetchToken, fetch);
+__NODE__ && app.register(I18nLoaderToken, I18nLoader);
+__BROWSER__ && app.register(HydrationStateToken, hydrationState);
+__BROWSER__ && app.register(FetchToken, fetch);
 ```
 
-- `I18n` - the core I18n library
-- `I18nLoader.from: (ctx: Context) => ({locale: string, translations: Object<string, string>})` - A function that provides translations
-  - `ctx: {headers: {'accept-language': string}}` - A Koa context object
-- `fetch` - a [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation
+##### Optional dependencies
+
+Name | Type | Default | Description
+-|-|-|-
+- `I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
+`HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client.  Browser only.
+`FetchToken` | `(url: string, options: Object) => Promise` | `window.fetch` | A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
 
 #### Factory
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ __BROWSER__ && app.register(FetchToken, fetch);
 
 Name | Type | Default | Description
 -|-|-|-
-- `I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
+`I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | `createI18nLoader()` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
 `HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client.  Browser only.
 `FetchToken` | `(url: string, options: Object) => Promise` | `window.fetch` | A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -27,7 +27,7 @@ export const HydrationStateToken = createToken('HydrationStateToken');
 export default __BROWSER__ &&
   createPlugin({
     deps: {
-      fetch: FetchToken,
+      fetch: FetchToken.optional,
       hydrationState: HydrationStateToken.optional,
     },
     provides: ({fetch = window.fetch, hydrationState} = {}) => {


### PR DESCRIPTION
Fixes #75  | Rendered: [link](https://github.com/AlexMSmithCA/fusion-plugin-i18n/blob/7d74f37624e0e28c072438f2eda880319cc4ddf4/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation