### PR TITLE
Update and standardize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,20 @@ If you're using React, you should use [`fusion-plugin-i18n-react`](https://githu
 
 ### Table of contents
 
-TBD
+* [fusion-plugin-i18n](#fusion-plugin-i18n)
+  * [Table of contents](#table-of-contents)
+  * [Installation](#installation)
+  * [Usage](#usage)
+    * [Simple middleware](#simple-middleware)
+  * [Setup](#setup)
+  * [API](#api)
+    * [Registration API](#registration-api)
+      * [`I18nLoaderToken`](#i18nloadertoken)
+      * [`HydrationStateToken`](#hydrationstatetoken)
+      * [`FetchToken`](#fetchtoken)
+    * [Service API](#service-api)
+  * [Other examples](#other-examples)
+    * [Custom translations loader example](#custom-translations-loader-example)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 [![Build status](https://badge.buildkite.com/3f2d84d5538d87a19677f5d79304ac46a8a67f970520d13884.svg?branch=master)](https://buildkite.com/uberopensource/fusion-plugin-i18n)
 
-Adds I18n (Internationalization) support to a Fusion.js app
+Adds I18n (Internationalization) string support to a Fusion.js app.
 
-For date i18n, consider using [date-fns](https://date-fns.org/)
+This plugin looks for translations in the `./translations` folder by default.  Translations for each language are expected to be in a JSON file with a [locale](https://www.npmjs.com/package/locale) as a filename.  For example, for U.S. English, translations should be in `./translations/en-US.json`.  Language tags are dictated by your browser, and likely follow the [RFC 5646](https://tools.ietf.org/html/rfc5646) specification.
 
 If you're using React, you should use [`fusion-plugin-i18n-react`](https://github.com/fusionjs/fusion-plugin-i18n-react) instead of this package.
+
+---
+
+### Table of contents
+
+TBD
 
 ---
 
@@ -18,12 +24,59 @@ yarn add fusion-plugin-i18n
 
 ---
 
-### Example
+### Usage
+
+#### Simple middleware
+
+The plugin provides a programatic interface which exposes `translate`.  See [Service API](#service-api) for more details.
+
+```js
+// src/some-middleware-plugin.js
+import {createPlugin} from 'fusion-core';
+
+export default createPlugin({
+  deps: {I18n: I18nToken},
+  middleware: ({I18n}) => {
+    return (ctx, next) => {
+      if (__NODE__ && ctx.path === '/some-path') {
+        const i18n = I18n.from(ctx);
+        ctx.body = {
+          message: i18n.translate('test', {name: 'world'}), // hello world
+        }
+      }
+      return next();
+    }
+  }
+});
+```
+
+The default loader expects translation files to live in `./translations/{locale}`.
+
+`./translations/en-US.json`
+
+```json
+{
+  "HomeHeader": "Welcome!",
+  "Greeting": "Hello, ${name}"
+}
+```
+
+`./translations/pt-BR.json`
+
+```json
+{
+  "HomeHeader": "Benvindo!",
+  "Greeting": "Olá, ${name}"
+}
+```
+
+---
+
+### Setup
 
 ```js
 // src/main.js
-import React from 'react';
-import App from 'fusion-react';
+import App from 'fusion-core';
 import I18n, {I18nToken, I18nLoaderToken, createI18nLoader} from 'fusion-plugin-i18n';
 import {FetchToken} from 'fusion-tokens';
 import fetch from 'unfetch';
@@ -33,35 +86,102 @@ export default () => {
 
   app.register(I18nToken, I18n);
   __NODE__
-    ? app.register(I18nLoaderToken, createI18nLoader());
+    ? app.register(I18nLoaderToken, createI18nLoader())
     : app.register(FetchToken, fetch);
-
-  app.middleware({I18n: I18nToken}, ({I18n}) => {
-    return (ctx, next) => {
-      if (__NODE__ && ctx.path === '/hello') {
-        const i18n = I18n.from(ctx);
-        ctx.body = {
-          message: i18n.translate('test', {name: 'world'}), // hello world
-        }
-      }
-      return next();
-    }
-  });
 
   return app;
 }
-// translations/en_US.json
-{
-  "test": "hello ${name}"
-}
 ```
 
-##### Custom translations loader example
+---
+
+### API
+
+#### Registration API
+
+##### `I18nLoaderToken`
+
+```js
+import {I18nLoaderToken} from 'fusion-plugin-i18n';
+```
+
+A function that provides translations.  Optional.  Server-side only.
+
+###### Type
+```js
+type I18nLoader = {
+  from: (ctx: Context) => ({locale: string, translations: Object})
+};
+```
+- `loader.from: (ctx) => ({locale, translations})` -
+  - `ctx: FusionContext` - Required. A [FusionJS context](https://github.com/fusionjs/fusion-core#context) object.
+  - `locale: Locale` - A [Locale](https://www.npmjs.com/package/locale)
+  - `translations: Object` - A object that maps translation keys to translated values for the given locale
+
+###### Default value
+
+If no loader is provided, the default loader will read translations from `./translations/{locale}.json`.  See [src/loader.js](https://github.com/fusionjs/fusion-plugin-i18n/blob/master/src/loader.js#L12) for more details.
+
+##### `HydrationStateToken`
+
+```js
+import {HydrationStateToken} from 'fusion-plugin-i18n';
+```
+
+Sets the hydrated state in the client, and can be useful for testing purposes.  Optional.  Browser only.
+
+###### Type
+```js
+type HydrationState = {
+  chunks: Array,
+  translations: Object
+};
+```
+
+###### Default value
+
+If no hydration state is provided, this will be an empty object (`{}`) and have no effect.
+
+##### `FetchToken`
+
+```js
+import {FetchToken} from 'fusion-tokens';
+```
+
+A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
+
+###### Type
+```js
+type Fetch = (url: string, options: Object) => Promise<Response>;
+```
+
+- `url: string` - Required.  Path or URL to the resource you wish to fetch.
+- `options: Object` - Optional.  You may optionally pass an `init` options object as the second argument.  See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) for more details.
+- `[return]: Promise<Request>` - Return value from fetch.  See [Response](A function that loads appropriate translations and locale information given an HTTP request context) for more details.
+
+###### Default value
+
+If no fetch implementation is provided, [`window.fetch`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) is used.
+
+#### Service API
+
+```js
+const translations: string = i18n.translate(key: string, interpolations: Object)
+```
+
+- `key: string` - A translation key. When using `createI18nLoader`, it refers to a object key in a translation json file.
+- `interpolations: object` - A object that maps an interpolation key to a value. For example, given a translation file `{"foo": "${bar} world"}`, the code `i18n.translate('foo', {bar: 'hello'})` returns `"hello world"`.
+- `translation: string` - A translation, or `key` if a matching translation could not be found.
+
+---
+
+### Other examples
+
+#### Custom translations loader example
 
 ```js
 // src/main.js
-import React from 'react';
-import App from 'fusion-react';
+import App from 'fusion-core';
 import I18n, {I18nToken, I18nLoaderToken} from 'fusion-plugin-i18n';
 import {FetchToken} from 'fusion-tokens';
 import fetch from 'unfetch';
@@ -97,64 +217,3 @@ export default (ctx) => {
   return {locale, translations};
 }
 ```
-
----
-
-### API
-
-#### Dependency registration
-
-```js
-import {I18nLoaderToken, HydrationStateToken} from 'fusion-plugin-i18n';
-import {FetchToken} from 'fusion-tokens';
-
-__NODE__ && app.register(I18nLoaderToken, I18nLoader);
-__BROWSER__ && app.register(HydrationStateToken, hydrationState);
-__BROWSER__ && app.register(FetchToken, fetch);
-```
-
-##### Optional dependencies
-
-Name | Type | Default | Description
--|-|-|-
-`I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | `createI18nLoader()` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
-`HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client.  Browser only.
-`FetchToken` | `(url: string, options: Object) => Promise` | `window.fetch` | A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
-
-#### Factory
-
-`const i18n = I18n.from(ctx)`
-
-- `ctx: FusionContext` - Required. A [Fusion.js context](https://github.com/fusionjs/fusion-core#context) object.
-
-#### Instance methods
-
-```js
-const translation = i18n.translate(key, interpolations)
-```
-
-- `key: string` - A translation key. When using `createI18nLoader`, it refers to a object key in a translation json file.
-- `interpolations: object` - A object that maps an interpolation key to a value. For example, given a translation file `{"foo": "${bar} world"}`, the code `i18n.translate('foo', {bar: 'hello'})` returns `"hello world"`.
-- `translation: string` - A translation, or `key` if a matching translation could not be found.
-
-#### Server-side loader
-
-This plugin has a simple loader implementation that looks for files in a `./translations` directory. Files should be named after their locales.
-
-```js
-import {I18nLoaderToken, createI18nLoader} from 'fusion-plugin-i18n';
-
-app.register(I18nLoaderToken, createI18nLoader());
-
-// translations/en_US.json
-{
-  "some-translation-key": "hello",
-}
-```
-
-`const loader = createI18nLoader()`
-
-- `loader.from: (ctx) => ({locale, translations})` - A function that loads appropriate translations and locale information given an HTTP request context
-  - `ctx: FusionContext` - Required. A [Fusion.js context](https://github.com/fusionjs/fusion-core#context) object.
-  - `locale: Locale` - A [Locale](https://www.npmjs.com/package/locale)
-  - `translations: Object` - A object that maps translation keys to translated values for the given locale

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yarn add fusion-plugin-i18n
 
 #### Simple middleware
 
-The plugin provides a programatic interface which exposes `translate`.  See [Service API](#service-api) for more details.
+The plugin provides a programmatic interface which exposes `translate`.  See [Service API](#service-api) for more details.
 
 ```js
 // src/some-middleware-plugin.js

--- a/README.md
+++ b/README.md
@@ -12,20 +12,18 @@ If you're using React, you should use [`fusion-plugin-i18n-react`](https://githu
 
 ### Table of contents
 
-* [fusion-plugin-i18n](#fusion-plugin-i18n)
-  * [Table of contents](#table-of-contents)
-  * [Installation](#installation)
-  * [Usage](#usage)
-    * [Simple middleware](#simple-middleware)
-  * [Setup](#setup)
-  * [API](#api)
-    * [Registration API](#registration-api)
-      * [`I18nLoaderToken`](#i18nloadertoken)
-      * [`HydrationStateToken`](#hydrationstatetoken)
-      * [`FetchToken`](#fetchtoken)
-    * [Service API](#service-api)
-  * [Other examples](#other-examples)
-    * [Custom translations loader example](#custom-translations-loader-example)
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Simple middleware](#simple-middleware)
+* [Setup](#setup)
+* [API](#api)
+  * [Registration API](#registration-api)
+    * [`I18nLoaderToken`](#i18nloadertoken)
+    * [`HydrationStateToken`](#hydrationstatetoken)
+    * [`FetchToken`](#fetchtoken)
+  * [Service API](#service-api)
+* [Other examples](#other-examples)
+  * [Custom translations loader example](#custom-translations-loader-example)
 
 ---
 


### PR DESCRIPTION
Fixes [#493](https://app.zenhub.com/workspace/o/uber-web/web-platform-tasks/issues/493) | [Rendered](https://github.com/AlexMSmithCA/fusion-plugin-i18n/blob/563999bbde87f7fd3f1f9195271ba0e492455391/README.md)

Similar to `fusion-plugin-i18n-react`.  Main changes are:
* Added note to use React version is applicable
* Simple middleware example
* Use `fusion-core` over `fusion-react`, and removed component / HOC usage examples