### PR TITLE
Remove yarn command to run flow check

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "flow": "flow check",
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",


### PR DESCRIPTION
Causes issues downstream in the verification step:

https://buildkite.com/uberopensource/fusion-release-verification/builds/155#ff3f42de-b049-4a2f-a1a2-7da63e4a4cfd

Error:

```sh
Could not find file or directory check; canceling search for .flowconfig.
```