### PR TITLE
Fix .flowconfig to not overwrite FlowFixMe

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,14 +1,15 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
+<PROJECT_ROOT>/dist/.*
 
 [include]
 ./src/
 
 [libs]
+./node_modules/fusion-core/flow-typed
 
 [lints]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
 
 [strict]

--- a/flow-typed/locale.js
+++ b/flow-typed/locale.js
@@ -1,0 +1,35 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare module 'locale' {
+  declare class Locale {
+    constructor(str: string): Locale;
+    normalized: string;
+
+    serialize: Function;
+    toString: Function;
+    toJSON: Function;
+  }
+
+  declare class Locales {
+    constructor(str: string[], def?: string): Locales;
+
+    length: number;
+    _index: any;
+    index: Function;
+
+    best: Function;
+
+    sort: Function;
+    push: Function;
+
+    serialize: Function;
+    toString: Function;
+    toJSON: Function;
+  }
+}


### PR DESCRIPTION
**Problem**

`.flowconfig` in a some repositories still override `$FlowFixMe` which causes release verification failures ([example](https://buildkite.com/uberopensource/fusion-release-verification/builds/268#f49f188d-63db-4a7f-a9ef-b8e228b16fdf)).

**Solution**

Identify and update the `.flowconfig` files for all of these offending repositories.
