### PR TITLE
Add nullable 'locale' to I18nServiceType

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -20,6 +20,7 @@ export type I18nServiceType = {
   from: (
     ctx?: Context
   ) => {
+    locale?: string,
     load: (chunkIds: Array<number>) => Promise<*>,
     translate: (key: string, interpolations?: Object) => string,
   },


### PR DESCRIPTION
As part of the fix for [WPT-547](https://jeng.uberinternal.com/browse/WPT-547)