### PR TITLE
Pass locale code as a header to translations request

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -102,12 +102,19 @@ test('load', t => {
   let called = false;
   const hydrationState = {
     chunks: [],
+    localeCode: 'es-MX',
     translations: {},
   };
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   const fetch = (url, options) => {
     t.equals(url, '/_translations?ids=0', 'url is ok');
     t.equals(options && options.method, 'POST', 'method is ok');
+    t.equals(
+      // $FlowFixMe
+      options && options.headers && options.headers['X-Fusion-Locale-Code'],
+      'es-MX',
+      'locale code header is ok'
+    );
     called = true;
     return Promise.resolve({json: () => data});
   };

--- a/src/node.js
+++ b/src/node.js
@@ -68,7 +68,10 @@ const plugin =
               translations[key] = i18n.translations[key];
             });
           });
-          const serialized = JSON.stringify({chunks, translations});
+          // i18n.locale is actually a locale.Locale instance
+          // $FlowFixMe
+          const localeCode = i18n.locale.code;
+          const serialized = JSON.stringify({chunks, localeCode, translations});
           const script = html`<script type='application/json' id="__TRANSLATIONS__">${serialized}</script>`; // consumed by ./browser
           // $FlowFixMe
           ctx.template.body.push(script);


### PR DESCRIPTION
When working with alternative I18n loaders that don't use `Accept-Language` header, it's useful to have a consistent understanding of what locale code is intended to be used. To facilitate this, this change echoes back the locale code as a `X-Fusion-Locale-Code` header in the request to `/_translations`.