### PR TITLE
Fix client-side loaded chunk tracking

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -125,6 +125,8 @@ test('load', t => {
     t.ok(called, 'fetch called');
     t.equals(i18n.translate('test'), 'hello');
     t.equals(i18n.translate('interpolated', {value: 'world'}), 'hi world');
+    // $FlowFixMe
+    t.same(i18n.loadedChunks, [0]);
     t.end();
   });
 });


### PR DESCRIPTION
In the i18n browser plugin, `loadedChunks` is treated as an array of chunk IDs that are loaded. Except in the final step where we add chunks that we loaded to the array, where it was being treated as an array of booleans and indexing by chunk IDs. This change fixes the bug by consistently treating `loadedChunks` as an array of chunk IDs.