### PR TITLE
Fix treeshaking for plugin exports

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -22,81 +22,85 @@ import type {
   TranslationsObjectType,
 } from './types.js';
 
-const plugin: FusionPlugin<I18nDepsType, I18nServiceType> = createPlugin({
-  deps: {
-    loader: I18nLoaderToken.optional,
-  },
-  provides: ({loader}) => {
-    class I18n {
-      translations: TranslationsObjectType;
-      locale: string | Locale;
+type PluginType = FusionPlugin<I18nDepsType, I18nServiceType>;
+const pluginFactory: () => PluginType = () =>
+  createPlugin({
+    deps: {
+      loader: I18nLoaderToken.optional,
+    },
+    provides: ({loader}) => {
+      class I18n {
+        translations: TranslationsObjectType;
+        locale: string | Locale;
 
-      constructor(ctx) {
-        if (!loader) {
-          loader = createLoader();
+        constructor(ctx) {
+          if (!loader) {
+            loader = createLoader();
+          }
+          const {translations, locale} = loader.from(ctx);
+          // eslint-disable-next-line no-console
+          this.translations = translations;
+          this.locale = locale;
         }
-        const {translations, locale} = loader.from(ctx);
-        // eslint-disable-next-line no-console
-        this.translations = translations;
-        this.locale = locale;
+        async load() {} //mirror client API
+        translate(key, interpolations = {}) {
+          const template = this.translations[key];
+          return template != null
+            ? template.replace(/\${(.*?)}/g, (_, k) => interpolations[k])
+            : key;
+        }
       }
-      async load() {} //mirror client API
-      translate(key, interpolations = {}) {
-        const template = this.translations[key];
-        return template != null
-          ? template.replace(/\${(.*?)}/g, (_, k) => interpolations[k])
-          : key;
-      }
-    }
 
-    const service = {from: memoize(ctx => new I18n(ctx))};
-    return service;
-  },
-  middleware: (_, plugin) => {
-    // TODO(#4) refactor: this currently depends on babel plugins in framework's webpack config.
-    // Ideally these babel plugins should be part of this package, not hard-coded in framework core
-    const chunkTranslationMap = require('../chunk-translation-map');
-    return async (ctx, next) => {
-      if (ctx.element) {
-        await next();
-        const i18n = plugin.from(ctx);
+      const service = {from: memoize(ctx => new I18n(ctx))};
+      return service;
+    },
+    middleware: (_, plugin) => {
+      // TODO(#4) refactor: this currently depends on babel plugins in framework's webpack config.
+      // Ideally these babel plugins should be part of this package, not hard-coded in framework core
+      const chunkTranslationMap = require('../chunk-translation-map');
+      return async (ctx, next) => {
+        if (ctx.element) {
+          await next();
+          const i18n = plugin.from(ctx);
 
-        // get the webpack chunks that are used and serialize their translations
-        const chunks: Array<string | number> = [
-          ...ctx.syncChunks,
-          ...ctx.preloadChunks,
-        ];
-        const translations = {};
-        chunks.forEach(id => {
-          const keys = Array.from(chunkTranslationMap.translationsForChunk(id));
-          keys.forEach(key => {
-            translations[key] = i18n.translations && i18n.translations[key];
+          // get the webpack chunks that are used and serialize their translations
+          const chunks: Array<string | number> = [
+            ...ctx.syncChunks,
+            ...ctx.preloadChunks,
+          ];
+          const translations = {};
+          chunks.forEach(id => {
+            const keys = Array.from(
+              chunkTranslationMap.translationsForChunk(id)
+            );
+            keys.forEach(key => {
+              translations[key] = i18n.translations && i18n.translations[key];
+            });
           });
-        });
-        // i18n.locale is actually a locale.Locale instance
-        // $FlowFixMe
-        const localeCode = i18n.locale.code;
-        const serialized = JSON.stringify({chunks, localeCode, translations});
-        const script = html`<script type='application/json' id="__TRANSLATIONS__">${serialized}</script>`; // consumed by ./browser
-        ctx.template.body.push(script);
-      } else if (ctx.path === '/_translations') {
-        const i18n = plugin.from(ctx);
-        const ids = querystring.parse(ctx.querystring).ids || '';
-        const chunks = ids.split(',').map(id => parseInt(id, 10));
-        const translations = {};
-        chunks.forEach(id => {
-          const keys = [...chunkTranslationMap.translationsForChunk(id)];
-          keys.forEach(key => {
-            translations[key] = i18n.translations && i18n.translations[key];
+          // i18n.locale is actually a locale.Locale instance
+          // $FlowFixMe
+          const localeCode = i18n.locale.code;
+          const serialized = JSON.stringify({chunks, localeCode, translations});
+          const script = html`<script type='application/json' id="__TRANSLATIONS__">${serialized}</script>`; // consumed by ./browser
+          ctx.template.body.push(script);
+        } else if (ctx.path === '/_translations') {
+          const i18n = plugin.from(ctx);
+          const ids = querystring.parse(ctx.querystring).ids || '';
+          const chunks = ids.split(',').map(id => parseInt(id, 10));
+          const translations = {};
+          chunks.forEach(id => {
+            const keys = [...chunkTranslationMap.translationsForChunk(id)];
+            keys.forEach(key => {
+              translations[key] = i18n.translations && i18n.translations[key];
+            });
           });
-        });
-        ctx.body = translations;
-        return next();
-      } else {
-        return next();
-      }
-    };
-  },
-});
+          ctx.body = translations;
+          return next();
+        } else {
+          return next();
+        }
+      };
+    },
+  });
 
-export default ((__NODE__ && plugin: any): typeof plugin);
+export default ((__NODE__ && pluginFactory(): any): PluginType);


### PR DESCRIPTION
Fixes [WPT-1422](https://jeng.uberinternal.com/browse/WPT-1422):

>Recent changes to fusion-plugin-i18n and fusion-plugin-rpc caused non-target implementations for plugins to bleed into bundles due to not being tree shaken out.

Thanks to @rtsao and @KevinGrandon for tracking down this issue!