### PR TITLE
Add flow-typed/ folder to export for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "files": [
     "dist",
     "chunk-translation-map.js",
+    "flow-typed",
     "src"
   ],
   "main": "./dist/index.js",


### PR DESCRIPTION
Includes type definitions for the `locale` package in [`flow-typed/locale.js'](https://github.com/fusionjs/fusion-plugin-i18n/blob/master/flow-typed/locale.js).