### PR TITLE
Export TranslationsObjectType and TranslateFuncType types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,25 @@ import type {FusionPlugin, Token} from 'fusion-core';
 import serverPlugin from './node';
 import clientPlugin, {HydrationStateToken} from './browser';
 import createI18nLoader from './loader';
-import type {I18nDepsType, I18nServiceType} from './types.js';
+import type {
+  I18nDepsType,
+  I18nServiceType,
+  TranslationsObjectType,
+  TranslateFuncType,
+} from './types.js';
 import {I18nLoaderToken} from './tokens.js';
 
-export type {I18nDepsType, I18nServiceType};
 const I18nToken: Token<I18nServiceType> = createToken('I18nToken');
 
 const plugin: FusionPlugin<I18nDepsType, I18nServiceType> = __NODE__
   ? serverPlugin
   : clientPlugin;
 
+export type {
+  I18nDepsType,
+  I18nServiceType,
+  TranslationsObjectType,
+  TranslateFuncType,
+};
 export default plugin;
 export {I18nToken, I18nLoaderToken, HydrationStateToken, createI18nLoader};

--- a/src/types.js
+++ b/src/types.js
@@ -16,6 +16,11 @@ import {I18nLoaderToken} from './tokens.js';
 
 export type TranslationsObjectType = {[string]: string};
 
+export type TranslateFuncType = (
+  key: string,
+  interpolations?: TranslationsObjectType
+) => string;
+
 export type I18nDepsType = {
   fetch?: typeof FetchToken.optional,
   hydrationState?: typeof HydrationStateToken.optional,
@@ -29,9 +34,6 @@ export type I18nServiceType = {
     +locale?: string | Locale,
     +translations?: TranslationsObjectType,
     +load: (chunkIds: Array<number | string>) => Promise<void>,
-    +translate: (
-      key: string,
-      interpolations?: TranslationsObjectType
-    ) => string,
+    +translate: TranslateFuncType,
   },
 };


### PR DESCRIPTION
Partially resolves [WPT-2853](https://jeng.uberinternal.com/browse/WPT-2853):

> ... it would be ideal the type for the translation function provided by the withTranslations HOC could be exported as well.